### PR TITLE
Add collection_id for remote

### DIFF
--- a/pkg/otbuiltin/remote.go
+++ b/pkg/otbuiltin/remote.go
@@ -28,6 +28,7 @@ type RemoteOptions struct {
 	TlsCaPath           string
 	UnconfiguredState   string
 	MinFreeSpacePercent string
+	CollectionId        string
 }
 
 func toDashString(in string) string {


### PR DESCRIPTION
Add CollectionId to be mapped to appropriate member of private
structure OstreeRepo.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>