### PR TITLE
Fix warning in builtin.go.h

### DIFF
--- a/pkg/otbuiltin/builtin.go.h
+++ b/pkg/otbuiltin/builtin.go.h
@@ -46,7 +46,7 @@ _guint_to_pointer (guint u)
 }
 
 static void
-_g_clear_object (volatile GObject **object_ptr)
+_g_clear_object (GObject **object_ptr)
 {
   g_clear_object(object_ptr);
 }


### PR DESCRIPTION
When building go-debos/debos with latest glib-2.0 I've got the following warnings multiple times:
```
# github.com/sjoerdsimons/ostree-go/pkg/otbuiltin
In file included from /usr/include/glib-2.0/glib/glist.h:32,
from /usr/include/glib-2.0/glib/ghash.h:33,
from /usr/include/glib-2.0/glib.h:50,
from ../../../../sjoerdsimons/ostree-go/pkg/otbuiltin/builtin.go:16:
../../../../sjoerdsimons/ostree-go/pkg/otbuiltin/builtin.go.h: In function '_g_clear_object':
/usr/include/glib-2.0/glib/gmem.h:121:18: warning: passing argument 1 of 'g_object_unref' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
(destroy) (_ptr); \
^~~~
/usr/include/glib-2.0/gobject/gobject.h:672:36: note: in expansion of macro 'g_clear_pointer'
#define g_clear_object(object_ptr) g_clear_pointer ((object_ptr), g_object_unref)
^~~~~~~~~~~~~~~
../../../../sjoerdsimons/ostree-go/pkg/otbuiltin/builtin.go.h:51:3: note: in expansion of macro 'g_clear_object'
g_clear_object(object_ptr);
^~~~~~~~~~~~~~
In file included from /usr/include/glib-2.0/gobject/gbinding.h:29,
from /usr/include/glib-2.0/glib-object.h:23,
from /usr/include/glib-2.0/gio/gioenums.h:28,
from /usr/include/glib-2.0/gio/giotypes.h:28,
from /usr/include/glib-2.0/gio/gio.h:26,
from /usr/include/ostree-1/ostree-types.h:26,
from /usr/include/ostree-1/ostree-async-progress.h:24,
from /usr/include/ostree-1/ostree.h:24,
from ../../../../sjoerdsimons/ostree-go/pkg/otbuiltin/builtin.go:17:
/usr/include/glib-2.0/gobject/gobject.h:494:64: note: expected 'gpointer' {aka 'void *'} but argument is of type 'volatile GObject *' {aka 'volatile struct _GObject *'}
void g_object_unref (gpointer object);
~~~~~~~~~~~~~~~~^~~~~~
```
Since glib-2-58 g_clear_object takes a non-volatile GObject** (cf. https://github.com/GNOME/glib/commit/2aacef39b1cfe4cc5eade704db05ffe1516be22e )

Signed-off-by: Frédéric Danis <frederic.danis@collabora.com>