### PR TITLE
Fix crash in InitializeFS with dangling ostree symbolic link

### DIFF
--- a/pkg/otbuiltin/sysroot.go
+++ b/pkg/otbuiltin/sysroot.go
@@ -64,7 +64,7 @@ func (s Sysroot) InitializeFS() error {
 		{"root", 0700},
 	}
 
-	if _, err := os.Stat(path.Join(s.path, "ostree")); err == nil {
+	if _, err := os.Lstat(path.Join(s.path, "ostree")); err == nil {
 		return errors.New("Filesystem already initialized for ostree")
 	}
 


### PR DESCRIPTION
InitializeFS() checks if the filesystem has already been initialized by checking existence of `sysroot`. This works fine with real directory or a symbolic link to an existing directory.
But this fails in case `sysroot` is a dangling symbolic link, with the following error:
```
goroutine 1 [syscall]:
runtime.cgocall(0x715d10, 0xc420125438, 0x73a4a0)
	/usr/lib/go-1.10/src/runtime/cgocall.go:128 +0x64 fp=0xc420125408 sp=0xc4201253d0 pc=0x407124
github.com/sjoerdsimons/ostree-go/pkg/otbuiltin._Cfunc_ostree_sysroot_ensure_initialized(0x7fa11c3fe010, 0x0, 0xc4201384c0, 0x0)
	_cgo_gotypes.go:1657 +0x4d fp=0xc420125438 sp=0xc420125408 pc=0x694f4d
github.com/sjoerdsimons/ostree-go/pkg/otbuiltin.(*Sysroot).EnsureInitialized.func1(0x7fa11c3fe010, 0x0, 0xc4201384c0, 0xc420274720)
	/home/fdanis/src/gocode/src/github.com/sjoerdsimons/ostree-go/pkg/otbuiltin/sysroot.go:85 +0x10c fp=0xc420125470 sp=0xc420125438 pc=0x6a06bc
github.com/sjoerdsimons/ostree-go/pkg/otbuiltin.(*Sysroot).EnsureInitialized(0xc420125610, 0x0, 0x101, 0x819b00)
	/home/fdanis/src/gocode/src/github.com/sjoerdsimons/ostree-go/pkg/otbuiltin/sysroot.go:85 +0x79 fp=0xc4201254a8 sp=0xc420125470 pc=0x69ac39
github.com/sjoerdsimons/ostree-go/pkg/otbuiltin.Sysroot.InitializeFS(0xc4201384b8, 0xc42013a940, 0xd, 0xc4201e7f20, 0x1d)
	/home/fdanis/src/gocode/src/github.com/sjoerdsimons/ostree-go/pkg/otbuiltin/sysroot.go:79 +0x210 fp=0xc420125610 sp=0xc4201254a8 pc=0x69ab20
github.com/go-debos/debos/actions.(*OstreeDeployAction).Run(0xc4201460a0, 0xc4200c8580, 0x0, 0x81e600)
	/home/fdanis/src/gocode/src/github.com/go-debos/debos/actions/ostree_deploy_action.go:121 +0x151 fp=0xc4201258d0 sp=0xc420125610 pc=0x6efe41
main.do_run(0xc42013a080, 0x5, 0xc420170000, 0xe, 0xe, 0xc4200c8580, 0x0)
	/home/fdanis/src/gocode/src/github.com/go-debos/debos/cmd/debos/debos.go:32 +0xa6 fp=0xc420125968 sp=0xc4201258d0 pc=0x710506
main.main()
	/home/fdanis/src/gocode/src/github.com/go-debos/debos/cmd/debos/debos.go:412 +0xd5e fp=0xc420125f88 sp=0xc420125968 pc=0x712d5e
runtime.main()
	/usr/lib/go-1.10/src/runtime/proc.go:198 +0x212 fp=0xc420125fe0 sp=0xc420125f88 pc=0x430952
runtime.goexit()
	/usr/lib/go-1.10/src/runtime/asm_amd64.s:2361 +0x1 fp=0xc420125fe8 sp=0xc420125fe0 pc=0x45ac11
```

Using `os.Lstat` instead of `os.Stat` allows to check existence of the directory in all cases.

Signed-off-by: Frédéric Danis <frederic.danis@collabora.com>